### PR TITLE
Add hero generator with OpenRouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "tailwindcss": "^4.1.4",
     "uuid": "^11.1.0",
     "vaul": "^1.1.2",
+    "@ai-sdk/openrouter": "^0.1.0",
     "vercel": "^41.6.1",
     "xml2js": "^0.6.2",
     "zod": "^3.24.3",

--- a/public/hero-instructions.json
+++ b/public/hero-instructions.json
@@ -1,0 +1,3 @@
+{
+  "instructions": "Describe Luke Nittmann in a short poetic hero section."
+}

--- a/public/hero.json
+++ b/public/hero.json
@@ -1,0 +1,4 @@
+{
+  "date": "2024-01-01T00:00:00Z",
+  "text": "placeholder hero text"
+}

--- a/src/app/api/hero/cron/route.ts
+++ b/src/app/api/hero/cron/route.ts
@@ -1,0 +1,10 @@
+import { readHeroInstructions, updateHeroFile } from '@/utils/hero'
+import { NextResponse } from 'next/server'
+
+export const runtime = 'edge'
+
+export async function GET() {
+  const prompt = await readHeroInstructions()
+  await updateHeroFile(prompt)
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/hero/instructions/route.ts
+++ b/src/app/api/hero/instructions/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+import { readHeroInstructions, writeHeroInstructions } from '@/utils/hero'
+
+export const runtime = 'edge'
+
+export async function GET() {
+  const instructions = await readHeroInstructions()
+  return NextResponse.json({ instructions })
+}
+
+export async function POST(req: Request) {
+  const { instructions } = await req.json()
+  await writeHeroInstructions(instructions)
+  return NextResponse.json({ instructions })
+}

--- a/src/app/api/hero/route.ts
+++ b/src/app/api/hero/route.ts
@@ -1,0 +1,14 @@
+import { openrouter } from '@ai-sdk/openrouter'
+import { streamText } from 'ai'
+
+export const runtime = 'edge'
+
+export async function POST(req: Request) {
+  const { instructions } = await req.json()
+  const result = await streamText({
+    model: openrouter('openai/gpt-4-turbo'),
+    system: 'You generate short poetic hero text for a personal website.',
+    prompt: instructions
+  })
+  return result.toTextStreamResponse()
+}

--- a/src/app/dev/instructions/page.tsx
+++ b/src/app/dev/instructions/page.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { notFound } from 'next/navigation'
+
+export default function InstructionsPage() {
+  if (process.env.NODE_ENV !== 'development') {
+    notFound()
+  }
+
+  const [text, setText] = useState('')
+  const [status, setStatus] = useState<'idle' | 'saved'>('idle')
+
+  useEffect(() => {
+    fetch('/api/hero/instructions')
+      .then((res) => res.json())
+      .then((data) => setText(data.instructions))
+  }, [])
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    await fetch('/api/hero/instructions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ instructions: text })
+    })
+    setStatus('saved')
+    setTimeout(() => setStatus('idle'), 2000)
+  }
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <form onSubmit={onSubmit} className="flex flex-col gap-2">
+        <textarea
+          className="border rounded p-2 text-black"
+          rows={8}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
+          Save
+        </button>
+        {status === 'saved' && <p className="text-green-500">Saved!</p>}
+      </form>
+    </div>
+  )
+}

--- a/src/utils/hero.ts
+++ b/src/utils/hero.ts
@@ -1,0 +1,38 @@
+import { join } from 'path'
+import { readFile, writeFile } from 'fs/promises'
+import { openrouter } from '@ai-sdk/openrouter'
+import { generateText } from 'ai'
+
+export async function generateHeroText(prompt: string) {
+  const { text } = await generateText({
+    model: openrouter('openai/gpt-4-turbo'),
+    system: 'You generate short poetic hero text for a personal website.',
+    prompt
+  })
+  return text
+}
+
+const instructionsPath = join(process.cwd(), 'public', 'hero-instructions.json')
+
+export async function readHeroInstructions() {
+  try {
+    const data = await readFile(instructionsPath, 'utf8')
+    return JSON.parse(data).instructions as string
+  } catch {
+    return 'Write a new hero text.'
+  }
+}
+
+export async function writeHeroInstructions(instructions: string) {
+  await writeFile(
+    instructionsPath,
+    JSON.stringify({ instructions }, null, 2)
+  )
+}
+
+export async function updateHeroFile(prompt: string) {
+  const text = await generateHeroText(prompt)
+  const filePath = join(process.cwd(), 'public', 'hero.json')
+  await writeFile(filePath, JSON.stringify({ date: new Date().toISOString(), text }))
+  return text
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,5 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export * from './hero'


### PR DESCRIPTION
## Summary
- add `@ai-sdk/openrouter` dependency
- generate hero text with Vercel AI SDK
- expose streaming `/api/hero` route
- add daily cron route to refresh hero text
- export helpers in utils
- reintroduce dev-only page for updating hero instructions
- persist instructions in `public/hero-instructions.json`
- add API endpoints to read/update hero instructions

## Testing
- `git status --short`
