### PR TITLE
Improve resume CSS and add LaTeX pipeline

### DIFF
--- a/docs/resume/generate-resume-latex.sh
+++ b/docs/resume/generate-resume-latex.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+cd "$(dirname "$0")"
+
+TEMPLATE="resume-template.tex"
+
+for file in resume.md resume-ford.md; do
+  name="${file%.md}"
+  pandoc "$file" -o "${name}.tex" --from markdown --template "$TEMPLATE"
+  pdflatex -interaction=nonstopmode "${name}.tex" >/dev/null
+  pdflatex -interaction=nonstopmode "${name}.tex" >/dev/null
+  ls -la "${name}.pdf"
+  rm -f "${name}.log" "${name}.aux"
+done

--- a/docs/resume/generate-resume.sh
+++ b/docs/resume/generate-resume.sh
@@ -3,13 +3,15 @@
 # Change to the script directory
 cd "$(dirname "$0")"
 
-# Run the md-to-pdf command
-npx md-to-pdf resume-ford-ios.md --stylesheet styles/resume.css --pdf-options '{"format": "A4", "margin": "3mm", "printBackground": true}'
 
-# Copy to the final filename
-cp resume-ford-ios.pdf resume-ford-ios.pdf
-
-# Show the file details
-ls -la resume-ford-ios.pdf
+# Generate PDF versions of the resumes
+for file in resume.md resume-ford.md; do
+  name="${file%.md}"
+  npx md-to-pdf "$file" \
+    --stylesheet styles/resume.css \
+    --pdf-options '{"format": "A4", "margin": "3mm", "printBackground": true}' \
+    -o "${name}.pdf"
+  ls -la "${name}.pdf"
+done
 
 echo "PDF generated successfully!" 

--- a/docs/resume/resume-ford.md
+++ b/docs/resume/resume-ford.md
@@ -19,7 +19,7 @@ https://luke-nittmann.vercel.app
   - Resolved customer issues through direct support and code changes
   - Promoted to SDE II and moved teams to Address Intelligence
 
-**Tech Stack:** 
+<p class="tech-stack"><strong>Tech Stack:</strong></p>
   - **Languages:** [C++](https://isocpp.org/), [Python](https://www.python.org/), [Ruby](https://www.ruby-lang.org/)
   - **Cloud:** [AWS](https://aws.amazon.com/), [EC2](https://aws.amazon.com/ec2/), [S3](https://aws.amazon.com/s3/), [CloudFront](https://aws.amazon.com/cloudfront/)
   - **Media:** [FFmpeg](https://ffmpeg.org/), [H.264/H.265](https://en.wikipedia.org/wiki/Advanced_Video_Coding), [VP9](https://en.wikipedia.org/wiki/VP9), [AV1](https://en.wikipedia.org/wiki/AV1)
@@ -36,7 +36,7 @@ https://luke-nittmann.vercel.app
   - Maintained high service reliability across multiple regions
   - Led migration from monolith to microservices architecture
 
-**Tech Stack:** 
+<p class="tech-stack"><strong>Tech Stack:</strong></p>
   - **Frontend:** [React Native](https://reactnative.dev/), [TypeScript](https://www.typescriptlang.org/), [Redux](https://redux.js.org/), [Jest](https://jestjs.io/)
   - **Cloud:** [AWS](https://aws.amazon.com/), [Lambda](https://aws.amazon.com/lambda/), [DynamoDB](https://aws.amazon.com/dynamodb/), [S3](https://aws.amazon.com/s3/), [CloudFormation](https://aws.amazon.com/cloudformation/)
   - **Backend:** [Java](https://www.java.com/), [Python](https://www.python.org/), [Node.js](https://nodejs.org/), [Redis](https://redis.io/)
@@ -55,7 +55,7 @@ https://luke-nittmann.vercel.app
   - Implemented mobile security best practices including secure authentication and data encryption
   - Optimized application performance through memory profiling and performance analysis
 
-**Tech Stack:** 
+<p class="tech-stack"><strong>Tech Stack:</strong></p>
   - **iOS:** [Swift](https://www.swift.org/), [SwiftUI](https://developer.apple.com/xcode/swiftui/), [Combine](https://developer.apple.com/documentation/combine), [Core Data](https://developer.apple.com/documentation/coredata)
   - **Architecture:** [MVVM](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93viewmodel), [Protocol-Oriented Programming](https://developer.apple.com/videos/play/wwdc2015/408/), [Dependency Injection](https://en.wikipedia.org/wiki/Dependency_injection)
   - **Testing:** [XCTest](https://developer.apple.com/documentation/xctest), [UI Testing](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/testing_with_xcode/chapters/09-ui_testing.html), [TDD](https://en.wikipedia.org/wiki/Test-driven_development)
@@ -73,7 +73,7 @@ https://luke-nittmann.vercel.app
   - Created robust state management system with efficient navigation patterns
   - Implemented app analytics and monitoring for user behavior tracking and crash reporting
 
-**Tech Stack:** 
+<p class="tech-stack"><strong>Tech Stack:</strong></p>
   - **iOS:** [Swift](https://www.swift.org/), [SwiftUI](https://developer.apple.com/xcode/swiftui/), [The Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture)
   - **State Management:** [Combine](https://developer.apple.com/documentation/combine), [Swift Concurrency](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html)
   - **Networking:** [URLSession](https://developer.apple.com/documentation/foundation/urlsession), [Alamofire](https://github.com/Alamofire/Alamofire), [Async/Await](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html)
@@ -92,7 +92,7 @@ https://luke-nittmann.vercel.app
   - Created extensive unit and UI testing suite with XCTest and CI integration
   - Implemented advanced memory management and performance optimization techniques
 
-**Tech Stack:** 
+<p class="tech-stack"><strong>Tech Stack:</strong></p>
   - **iOS:** [Swift](https://www.swift.org/), [SwiftUI](https://developer.apple.com/xcode/swiftui/), [Combine](https://developer.apple.com/documentation/combine), [Core Data](https://developer.apple.com/documentation/coredata)
   - **Architecture:** [MVVM](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93viewmodel), [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
   - **Audio:** [AVFoundation](https://developer.apple.com/av-foundation/), [AudioKit](https://audiokit.io/), [CoreAudio](https://developer.apple.com/documentation/coreaudio), [MIDIKit](https://github.com/orchetect/MIDIKit)
@@ -109,7 +109,7 @@ https://luke-nittmann.vercel.app
   - Developed comprehensive automated testing framework
   - Implemented enterprise-grade security features for sensitive user data
 
-**Tech Stack:** 
+<p class="tech-stack"><strong>Tech Stack:</strong></p>
   - **iOS:** [Swift](https://www.swift.org/), [SwiftUI](https://developer.apple.com/xcode/swiftui/)
   - **Architecture:** [The Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture), [MVVM](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93viewmodel)
   - **Cross-platform:** [Tauri](https://tauri.app/) (iOS/macOS native support)
@@ -125,7 +125,7 @@ https://luke-nittmann.vercel.app
   - Built distributed job queue for resilient scheduled data updates
   - Developed relational schema with rich entity relationships
 
-**Tech Stack:** 
+<p class="tech-stack"><strong>Tech Stack:</strong></p>
   - **Frontend:** [Next.js](https://nextjs.org/), [TypeScript](https://www.typescriptlang.org/), [Tailwind](https://tailwindcss.com/), [Framer Motion](https://www.framer.com/motion/), [Recharts](https://recharts.org/)
   - **Backend:** [Prisma](https://www.prisma.io/), [Redis](https://redis.io/), [Upstash](https://upstash.com/), [tRPC](https://trpc.io/)
   - **Database:** [PostgreSQL](https://www.postgresql.org/)

--- a/docs/resume/resume-template.tex
+++ b/docs/resume/resume-template.tex
@@ -1,0 +1,9 @@
+\documentclass[10pt]{article}
+\usepackage[margin=1in]{geometry}
+\usepackage{enumitem}
+\setlist{nosep}
+\usepackage{parskip}
+\linespread{1.1}
+\begin{document}
+$body$
+\end{document}

--- a/docs/resume/resume.md
+++ b/docs/resume/resume.md
@@ -20,7 +20,7 @@ Building production-grade applications, focusing on AI-native experiences and th
 - Implemented adaptive suggestion engine with contextual intelligence
 - Developed secure subscription management with Stripe integration
 - Created cross-platform experience with Tauri (iOS/macOS native support)
-- **Tech Stack:** 
+- <span class="tech-stack">**Tech Stack:**</span> 
   - **Frontend:** [Next.js](https://nextjs.org/), [React](https://react.dev/), [TypeScript](https://www.typescriptlang.org/), [Tailwind](https://tailwindcss.com/), [Framer Motion](https://www.framer.com/motion/)
   - **Backend:** [Prisma](https://www.prisma.io/), [PostgreSQL](https://www.postgresql.org/)
   - **AI/ML:** [Gemini API](https://ai.google.dev/), Prompt Engineering
@@ -35,7 +35,7 @@ Building production-grade applications, focusing on AI-native experiences and th
 - Generated personalized job application cards from user's links, resume, and web presence
 - Implemented context-aware prompt engineering for coherent AI responses
 - Created serverless AI processing pipeline with edge function optimization
-- **Tech Stack:** 
+- <span class="tech-stack">**Tech Stack:**</span> 
   - **Frontend:** [Next.js](https://nextjs.org/), [React](https://react.dev/), [TypeScript](https://www.typescriptlang.org/), [Tailwind](https://tailwindcss.com/), [Framer Motion](https://www.framer.com/motion/), [shadcn/ui](https://ui.shadcn.com/)
   - **Backend:** [Prisma](https://www.prisma.io/), [NextAuth](https://next-auth.js.org/)
   - **Database:** [Neon Database](https://neon.tech/), [Vercel KV](https://vercel.com/storage/kv), [pgvector](https://github.com/pgvector/pgvector)
@@ -48,7 +48,7 @@ Building production-grade applications, focusing on AI-native experiences and th
 - Implemented intelligent content analysis with entity recognition using agentic workflows
 - Built distributed job queue for resilient scheduled data updates
 - Developed relational schema with rich entity relationships
-- **Tech Stack:** 
+- <span class="tech-stack">**Tech Stack:**</span> 
   - **Frontend:** [Next.js](https://nextjs.org/), [TypeScript](https://www.typescriptlang.org/), [Tailwind](https://tailwindcss.com/), [Framer Motion](https://www.framer.com/motion/), [Recharts](https://recharts.org/)
   - **Backend:** [Prisma](https://www.prisma.io/), [Redis](https://redis.io/), [Upstash](https://upstash.com/), [tRPC](https://trpc.io/)
   - **Database:** [PostgreSQL](https://www.postgresql.org/)
@@ -62,7 +62,7 @@ Building production-grade applications, focusing on AI-native experiences and th
 - Built real-time collaborative boards with interactive comments
 - Created modular, service-based FastAPI backend with monorepo webapp
 - Implemented fluid animations and interactions for enhanced UX
-- **Tech Stack:** 
+- <span class="tech-stack">**Tech Stack:**</span> 
   - **Frontend:** [Next.js](https://nextjs.org/), [TypeScript](https://www.typescriptlang.org/), [Tailwind](https://tailwindcss.com/), [Motion](https://motion.dev/), [Radix UI](https://www.radix-ui.com/), [react-spring](https://www.react-spring.dev/)
   - **Backend:** [Python](https://www.python.org/), [FastAPI](https://fastapi.tiangolo.com/), [asyncio](https://docs.python.org/3/library/asyncio.html), [pydantic](https://docs.pydantic.dev/)
   - **Database:** [PostgreSQL](https://www.postgresql.org/), [pgvector](https://github.com/pgvector/pgvector), [Neon](https://neon.tech/)
@@ -77,7 +77,7 @@ Building production-grade applications, focusing on AI-native experiences and th
 - Built AI-powered stem isolation system for vocals, drums, bass, and other
 - Implemented client-side audio processing engine with Web Audio API
 - Developed efficient audio file streaming and caching system
-- **Tech Stack:** 
+- <span class="tech-stack">**Tech Stack:**</span> 
   - **Frontend:** [Next.js](https://nextjs.org/), [React](https://react.dev/), [TypeScript](https://www.typescriptlang.org/), [Tailwind](https://tailwindcss.com/), [Framer Motion](https://www.framer.com/motion/)
   - **Audio:** [Tone.js](https://tonejs.github.io/), [Web Audio API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API), [AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorklet), [WebMIDI](https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API), [FFmpeg.wasm](https://ffmpegwasm.github.io/)
   - **Backend:** [FastAPI](https://fastapi.tiangolo.com/), [Python](https://www.python.org/)
@@ -92,7 +92,7 @@ Building production-grade applications, focusing on AI-native experiences and th
 - Developed web-based MIDI/sound pack upload utility
 - Implemented AI audio manipulation and semantic search with agentic asset organization
 - Created real-time sync with websocket streaming
-- **Tech Stack:** 
+- <span class="tech-stack">**Tech Stack:**</span> 
   - **iOS:** [Swift](https://www.swift.org/), [AVFoundation](https://developer.apple.com/av-foundation/), [AudioKit](https://audiokit.io/), [CoreAudio](https://developer.apple.com/documentation/coreaudio), [MIDIKit](https://github.com/orchetect/MIDIKit), [App Intents](https://developer.apple.com/documentation/appintents)
   - **Web:** [Next.js](https://nextjs.org/), [TypeScript](https://www.typescriptlang.org/)
   - **Audio:** [Pedalboard](https://github.com/spotify/pedalboard), [FFmpeg](https://ffmpeg.org/), [Soundpipe](https://github.com/PaulBatchelor/Soundpipe), [AudioUnits](https://developer.apple.com/documentation/audiounit), [VST3](https://www.steinberg.net/developers/)
@@ -107,7 +107,7 @@ Building production-grade applications, focusing on AI-native experiences and th
 - Led development of cross-platform notification system for web3 image generation platform
 - Built semantic image search system with Gemini multimodal embeddings and agentic asset organization
 - Architected full-stack features across iOS, web, and backend systems
-- **Tech Stack:** 
+- <span class="tech-stack">**Tech Stack:**</span> 
   - **Frontend:** [React](https://react.dev/), [TypeScript](https://www.typescriptlang.org/), [Tailwind CSS](https://tailwindcss.com/), [React Three Fiber](https://docs.pmnd.rs/react-three-fiber/getting-started/introduction)
   - **Mobile:** [Swift](https://www.swift.org/), [SwiftUI](https://developer.apple.com/xcode/swiftui/)
   - **Backend:** [Firebase](https://firebase.google.com/), [Cloud Functions](https://firebase.google.com/docs/functions), [Firestore](https://firebase.google.com/docs/firestore)
@@ -123,7 +123,7 @@ Building production-grade applications, focusing on AI-native experiences and th
 - Integrated Python audio models and CoreML for on-device audio processing
 - Optimized processing costs through AI-powered effects generation
 - Built integration layer supporting major streaming platforms (Spotify, Apple Music)
-- **Tech Stack:** 
+- <span class="tech-stack">**Tech Stack:**</span> 
   - **Mobile:** [Swift](https://www.swift.org/), [AVFoundation](https://developer.apple.com/av-foundation/), [CoreAudio](https://developer.apple.com/documentation/coreaudio), [AudioKit](https://audiokit.io/), [MIDI](https://developer.apple.com/documentation/coremidi)
   - **Frontend:** [React](https://react.dev/), [WebGL](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API)
   - **Backend:** [Python](https://www.python.org/), [Golang](https://go.dev/), [FastAPI](https://fastapi.tiangolo.com/), [GraphQL](https://graphql.org/), [Redis](https://redis.io/)
@@ -140,7 +140,7 @@ Building production-grade applications, focusing on AI-native experiences and th
 - Built self-service permission system automating internal workflows
 - Maintained high service reliability across multiple regions
 - Led migration from monolith to microservices architecture
-- **Tech Stack:** 
+- <span class="tech-stack">**Tech Stack:**</span> 
   - **Frontend:** [React Native](https://reactnative.dev/), [TypeScript](https://www.typescriptlang.org/), [Redux](https://redux.js.org/), [Jest](https://jestjs.io/)
   - **Cloud:** [AWS](https://aws.amazon.com/), [Lambda](https://aws.amazon.com/lambda/), [DynamoDB](https://aws.amazon.com/dynamodb/), [S3](https://aws.amazon.com/s3/), [CloudFormation](https://aws.amazon.com/cloudformation/)
   - **Backend:** [Java](https://www.java.com/), [Python](https://www.python.org/), [Node.js](https://nodejs.org/), [Redis](https://redis.io/)
@@ -154,7 +154,7 @@ Building production-grade applications, focusing on AI-native experiences and th
 - Rewrote Quicktime decoder enhancing metadata parsing accuracy
 - Developed automated testing framework for validation components
 - Resolved customer issues through direct support and code changes
-- **Tech Stack:** 
+- <span class="tech-stack">**Tech Stack:**</span> 
   - **Languages:** [C++](https://isocpp.org/), [Python](https://www.python.org/), [Ruby](https://www.ruby-lang.org/)
   - **Cloud:** [AWS](https://aws.amazon.com/), [EC2](https://aws.amazon.com/ec2/), [S3](https://aws.amazon.com/s3/), [CloudFront](https://aws.amazon.com/cloudfront/)
   - **Media:** [FFmpeg](https://ffmpeg.org/), [H.264/H.265](https://en.wikipedia.org/wiki/Advanced_Video_Coding), [VP9](https://en.wikipedia.org/wiki/VP9), [AV1](https://en.wikipedia.org/wiki/AV1)

--- a/docs/resume/styles/resume.css
+++ b/docs/resume/styles/resume.css
@@ -47,6 +47,20 @@ h1, h2, h3, h4, p, ul, li {
   padding: 0.3em;
 }
 
+p, li {
+  line-height: 1.15;
+}
+
+h1 {
+  line-height: 1.1;
+}
+
+h2,
+h3,
+h4 {
+  line-height: 1.1;
+}
+
 /* Header name styling */
 h1 {
   color: hsl(var(--primary));
@@ -55,7 +69,6 @@ h1 {
   margin-bottom: 0.2em;
   text-align: left;
   font-weight: bold;
-  line-height: 1;
 }
 
 /* Section headings */
@@ -68,7 +81,6 @@ h2 {
   margin-bottom: 0.2em;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  line-height: 1;
 }
 
 /* Subsection headings */
@@ -78,7 +90,6 @@ h3 {
   margin-bottom: 0.2em;
   margin-top: 0.3em;
   font-weight: bold;
-  line-height: 1.1;
 }
 
 /* Project titles */
@@ -88,7 +99,6 @@ h4 {
   margin-top: 0.2em;
   margin-bottom: 0.2em;
   color: hsl(var(--foreground));
-  line-height: 1.1;
 }
 
 /* Project links */
@@ -121,7 +131,7 @@ p:nth-of-type(3),
 p:nth-of-type(4) {
   text-align: left;
   margin: 0;
-  line-height: 1;
+  line-height: 1.15;
   font-size: 6pt;
   color: hsl(var(--muted-foreground));
 }
@@ -136,7 +146,6 @@ li {
   margin-bottom: 0;
   padding-left: 0;
   font-size: 6pt;
-  line-height: 1;
 }
 
 a {
@@ -161,7 +170,6 @@ ul li ul {
 
 ul li ul li {
   margin-bottom: 0;
-  line-height: 1;
   font-size: 6pt;
 }
 
@@ -197,12 +205,12 @@ li ul {
 }
 
 /* Ultra compact formatting for Tech Stack sections */
-li:contains("Tech Stack") {
+.tech-stack {
   margin-top: 0.6em !important;
   padding-top: 0.2em !important;
 }
 
-li:contains("Tech Stack") + ul {
+.tech-stack + ul {
   margin-top: 0;
   columns: 5;
   column-gap: 0.3em;
@@ -235,7 +243,7 @@ h3 + p {
 }
 
 /* Add spacing before Tech Stack section */
-li:contains("Tech Stack") {
+.tech-stack {
   margin-top: 0.6em !important;
   padding-top: 0.2em !important;
   border-top: 0.5pt solid transparent;
@@ -247,7 +255,7 @@ li:contains("Tech Stack") {
 }
 
 /* Tech stack items in pill style */
-li:contains("Tech Stack") + ul li {
+.tech-stack + ul li {
   display: inline-block;
   margin-right: 0.1em;
   margin-bottom: 0.08em;
@@ -301,7 +309,7 @@ li:contains("Tech Stack") + ul li {
   
   /* Tech pill styling for print */
   #skills ~ h3 + ul > li,
-  li:contains("Tech Stack") + ul li {
+  .tech-stack + ul li {
     background-color: #f5f7fa;
     border: 0.5pt solid #e4e7ec;
     color: #1e293b;
@@ -310,7 +318,7 @@ li:contains("Tech Stack") + ul li {
   }
   
   /* Tech Stack spacing for print */
-  li:contains("Tech Stack") {
+  .tech-stack {
     margin-top: 0.5em !important;
     padding-top: 0.2em !important;
   }


### PR DESCRIPTION
## Summary
- tweak resume line heights and remove invalid `:contains` selectors
- update resume markdown files to use `.tech-stack` class
- fix `generate-resume.sh` to build the correct PDFs
- add LaTeX resume template and build script

## Testing
- `bash -n docs/resume/generate-resume.sh`
- `bash -n docs/resume/generate-resume-latex.sh`
